### PR TITLE
update go-ds-datastore v0.5.1

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -1,6 +1,7 @@
 package badger
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -188,7 +189,7 @@ func (d *Datastore) periodicGC() {
 // NewTransaction starts a new transaction. The resulting transaction object
 // can be mutated without incurring changes to the underlying Datastore until
 // the transaction is Committed.
-func (d *Datastore) NewTransaction(readOnly bool) (ds.Txn, error) {
+func (d *Datastore) NewTransaction(_ context.Context, readOnly bool) (ds.Txn, error) {
 	return d.newTransaction(readOnly)
 }
 
@@ -215,7 +216,7 @@ func (d *Datastore) newImplicitTransaction(readOnly bool) *txn {
 	return &txn{d, d.DB.NewTransaction(!readOnly), true}
 }
 
-func (d *Datastore) Put(key ds.Key, value []byte) error {
+func (d *Datastore) Put(_ context.Context, key ds.Key, value []byte) error {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -232,7 +233,7 @@ func (d *Datastore) Put(key ds.Key, value []byte) error {
 	return txn.commit()
 }
 
-func (d *Datastore) Sync(prefix ds.Key) error {
+func (d *Datastore) Sync(_ context.Context, prefix ds.Key) error {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -246,7 +247,7 @@ func (d *Datastore) Sync(prefix ds.Key) error {
 	return d.DB.Sync()
 }
 
-func (d *Datastore) PutWithTTL(key ds.Key, value []byte, ttl time.Duration) error {
+func (d *Datastore) PutWithTTL(_ context.Context, key ds.Key, value []byte, ttl time.Duration) error {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -263,7 +264,7 @@ func (d *Datastore) PutWithTTL(key ds.Key, value []byte, ttl time.Duration) erro
 	return txn.commit()
 }
 
-func (d *Datastore) SetTTL(key ds.Key, ttl time.Duration) error {
+func (d *Datastore) SetTTL(_ context.Context, key ds.Key, ttl time.Duration) error {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -280,7 +281,7 @@ func (d *Datastore) SetTTL(key ds.Key, ttl time.Duration) error {
 	return txn.commit()
 }
 
-func (d *Datastore) GetExpiration(key ds.Key) (time.Time, error) {
+func (d *Datastore) GetExpiration(_ context.Context, key ds.Key) (time.Time, error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -293,7 +294,7 @@ func (d *Datastore) GetExpiration(key ds.Key) (time.Time, error) {
 	return txn.getExpiration(key)
 }
 
-func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
+func (d *Datastore) Get(_ context.Context, key ds.Key) (value []byte, err error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -306,7 +307,7 @@ func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
 	return txn.get(key)
 }
 
-func (d *Datastore) Has(key ds.Key) (bool, error) {
+func (d *Datastore) Has(_ context.Context, key ds.Key) (bool, error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -319,7 +320,7 @@ func (d *Datastore) Has(key ds.Key) (bool, error) {
 	return txn.has(key)
 }
 
-func (d *Datastore) GetSize(key ds.Key) (size int, err error) {
+func (d *Datastore) GetSize(_ context.Context, key ds.Key) (size int, err error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -332,7 +333,7 @@ func (d *Datastore) GetSize(key ds.Key) (size int, err error) {
 	return txn.getSize(key)
 }
 
-func (d *Datastore) Delete(key ds.Key) error {
+func (d *Datastore) Delete(_ context.Context, key ds.Key) error {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 
@@ -347,7 +348,7 @@ func (d *Datastore) Delete(key ds.Key) error {
 	return txn.commit()
 }
 
-func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
+func (d *Datastore) Query(_ context.Context, q dsq.Query) (dsq.Results, error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -405,7 +406,7 @@ func (d *Datastore) Close() error {
 
 // Batch creats a new Batch object. This provides a way to do many writes, when
 // there may be too many to fit into a single transaction.
-func (d *Datastore) Batch() (ds.Batch, error) {
+func (d *Datastore) Batch(_ context.Context) (ds.Batch, error) {
 	d.closeLk.RLock()
 	defer d.closeLk.RUnlock()
 	if d.closed {
@@ -423,7 +424,7 @@ func (d *Datastore) Batch() (ds.Batch, error) {
 	return b, nil
 }
 
-func (d *Datastore) CollectGarbage() (err error) {
+func (d *Datastore) CollectGarbage(_ context.Context) (err error) {
 	// The idea is to keep calling DB.RunValueLogGC() till Badger no longer has any log files
 	// to GC(which would be indicated by an error, please refer to Badger GC docs).
 	for err == nil {
@@ -448,7 +449,7 @@ func (d *Datastore) gcOnce() error {
 
 var _ ds.Batch = (*batch)(nil)
 
-func (b *batch) Put(key ds.Key, value []byte) error {
+func (b *batch) Put(_ context.Context, key ds.Key, value []byte) error {
 	b.ds.closeLk.RLock()
 	defer b.ds.closeLk.RUnlock()
 	if b.ds.closed {
@@ -461,7 +462,7 @@ func (b *batch) put(key ds.Key, value []byte) error {
 	return b.writeBatch.Set(key.Bytes(), value)
 }
 
-func (b *batch) Delete(key ds.Key) error {
+func (b *batch) Delete(_ context.Context, key ds.Key) error {
 	b.ds.closeLk.RLock()
 	defer b.ds.closeLk.RUnlock()
 	if b.ds.closed {
@@ -475,7 +476,7 @@ func (b *batch) delete(key ds.Key) error {
 	return b.writeBatch.Delete(key.Bytes())
 }
 
-func (b *batch) Commit() error {
+func (b *batch) Commit(_ context.Context) error {
 	b.ds.closeLk.RLock()
 	defer b.ds.closeLk.RUnlock()
 	if b.ds.closed {
@@ -515,7 +516,7 @@ func (b *batch) cancel() {
 var _ ds.Datastore = (*txn)(nil)
 var _ ds.TTLDatastore = (*txn)(nil)
 
-func (t *txn) Put(key ds.Key, value []byte) error {
+func (t *txn) Put(_ context.Context, key ds.Key, value []byte) error {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -528,7 +529,7 @@ func (t *txn) put(key ds.Key, value []byte) error {
 	return t.txn.Set(key.Bytes(), value)
 }
 
-func (t *txn) Sync(prefix ds.Key) error {
+func (t *txn) Sync(_ context.Context, prefix ds.Key) error {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -538,7 +539,7 @@ func (t *txn) Sync(prefix ds.Key) error {
 	return nil
 }
 
-func (t *txn) PutWithTTL(key ds.Key, value []byte, ttl time.Duration) error {
+func (t *txn) PutWithTTL(_ context.Context, key ds.Key, value []byte, ttl time.Duration) error {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -551,7 +552,7 @@ func (t *txn) putWithTTL(key ds.Key, value []byte, ttl time.Duration) error {
 	return t.txn.SetEntry(badger.NewEntry(key.Bytes(), value).WithTTL(ttl))
 }
 
-func (t *txn) GetExpiration(key ds.Key) (time.Time, error) {
+func (t *txn) GetExpiration(_ context.Context, key ds.Key) (time.Time, error) {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -571,7 +572,7 @@ func (t *txn) getExpiration(key ds.Key) (time.Time, error) {
 	return time.Unix(int64(item.ExpiresAt()), 0), nil
 }
 
-func (t *txn) SetTTL(key ds.Key, ttl time.Duration) error {
+func (t *txn) SetTTL(_ context.Context, key ds.Key, ttl time.Duration) error {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -592,7 +593,7 @@ func (t *txn) setTTL(key ds.Key, ttl time.Duration) error {
 
 }
 
-func (t *txn) Get(key ds.Key) ([]byte, error) {
+func (t *txn) Get(_ context.Context, key ds.Key) ([]byte, error) {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -614,7 +615,7 @@ func (t *txn) get(key ds.Key) ([]byte, error) {
 	return item.ValueCopy(nil)
 }
 
-func (t *txn) Has(key ds.Key) (bool, error) {
+func (t *txn) Has(_ context.Context, key ds.Key) (bool, error) {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -636,7 +637,7 @@ func (t *txn) has(key ds.Key) (bool, error) {
 	}
 }
 
-func (t *txn) GetSize(key ds.Key) (int, error) {
+func (t *txn) GetSize(_ context.Context, key ds.Key) (int, error) {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -658,7 +659,7 @@ func (t *txn) getSize(key ds.Key) (int, error) {
 	}
 }
 
-func (t *txn) Delete(key ds.Key) error {
+func (t *txn) Delete(_ context.Context, key ds.Key) error {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -672,7 +673,7 @@ func (t *txn) delete(key ds.Key) error {
 	return t.txn.Delete(key.Bytes())
 }
 
-func (t *txn) Query(q dsq.Query) (dsq.Results, error) {
+func (t *txn) Query(_ context.Context, q dsq.Query) (dsq.Results, error) {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -878,7 +879,7 @@ func (t *txn) query(q dsextensions.QueryExt) (dsq.Results, error) {
 	return qrb.Results(), nil
 }
 
-func (t *txn) Commit() error {
+func (t *txn) Commit(_ context.Context) error {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {
@@ -906,7 +907,7 @@ func (t *txn) close() error {
 	return t.txn.Commit()
 }
 
-func (t *txn) Discard() {
+func (t *txn) Discard(_ context.Context) {
 	t.ds.closeLk.RLock()
 	defer t.ds.closeLk.RUnlock()
 	if t.ds.closed {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/textileio/go-ds-badger3
 
 require (
 	github.com/dgraph-io/badger/v3 v3.2011.1
-	github.com/ipfs/go-datastore v0.4.5
+	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-log/v2 v2.1.1
 	github.com/jbenet/goprocess v0.1.4
 	github.com/textileio/go-datastore-extensions v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,23 @@ require (
 	go.uber.org/zap v1.16.0
 )
 
-go 1.14
+require (
+	github.com/DataDog/zstd v1.4.1 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
+	github.com/golang/protobuf v1.3.1 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/flatbuffers v1.12.0 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/ipfs/go-detect-race v0.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	go.opencensus.io v0.22.5 // indirect
+	go.uber.org/atomic v1.6.0 // indirect
+	go.uber.org/multierr v1.5.0 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f // indirect
+)
+
+go 1.17

--- a/go.sum
+++ b/go.sum
@@ -47,7 +47,6 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/ipfs/go-datastore v0.4.5 h1:cwOUcGMLdLPWgu3SlrCckCMznaGADbPqE0r8h768/Dg=
 github.com/ipfs/go-datastore v0.4.5/go.mod h1:eXTcaaiN6uOlVCLS9GjJUJtlvJfM3xk23w3fyfrmmJs=
 github.com/ipfs/go-datastore v0.5.1 h1:WkRhLuISI+XPD0uk3OskB0fYFSyqK8Ob5ZYew9Qa1nQ=
 github.com/ipfs/go-datastore v0.5.1/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,10 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ipfs/go-datastore v0.4.5 h1:cwOUcGMLdLPWgu3SlrCckCMznaGADbPqE0r8h768/Dg=
 github.com/ipfs/go-datastore v0.4.5/go.mod h1:eXTcaaiN6uOlVCLS9GjJUJtlvJfM3xk23w3fyfrmmJs=
+github.com/ipfs/go-datastore v0.5.1 h1:WkRhLuISI+XPD0uk3OskB0fYFSyqK8Ob5ZYew9Qa1nQ=
+github.com/ipfs/go-datastore v0.5.1/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
+github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
+github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-log/v2 v2.1.1 h1:G4TtqN+V9y9HY9TA6BwbCVyyBZ2B9MbCjR2MtGx8FR0=
 github.com/ipfs/go-log/v2 v2.1.1/go.mod h1:2v2nsGfZsvvAJz13SyFzf9ObaqwHiHxsPLEHntrv9KM=


### PR DESCRIPTION
Update to `go-datastore@v0.5.1`. This is a breaking change API in the interfaces.

Unfortunately, this is quite painful to do since affects every other project that uses `go-datastore`, so each of them will have to do its own work to adjust. In this PR we deal with an implementation using badger.